### PR TITLE
Refactor `PrivatAvtaleDto` and enhance PDF request handling

### DIFF
--- a/bidrag-dokumentmal/app/types/bidragskalkulator.ts
+++ b/bidrag-dokumentmal/app/types/bidragskalkulator.ts
@@ -78,13 +78,17 @@ export interface IOppgjør {
 
 export interface PrivatAvtaleDto {
   språk: SpråkkodeIdKey;
-  navSkjemaId: NavSkjemaIdKey;
   bidragsmottaker: IPerson;
   bidragspliktig: IPerson;
   barn: IBarnOgBidrag[];
   oppgjør: IOppgjør;
   andreBestemmelser: IAndreBestemmelser;
   vedlegg: Vedleggskrav;
+}
+
+export interface GenererPrivatAvtalePdfRequest {
+  privatAvtalePdf: PrivatAvtaleDto;
+  navSkjemaId: NavSkjemaIdKey;
 }
 
 export enum NavSkjemaId {


### PR DESCRIPTION
```
### Description
Refactored code to introduce `GenererPrivatAvtalePdfRequest` for better type separation. Updated the structure of the `PrivatAvtaleDto` and adjusted mappings associated with `bidragskalkulator.privatavtale` components to improve maintainability and clarity.
